### PR TITLE
fix(main.js): fix wrong pulseId detection for post urls

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -201,7 +201,7 @@ async function getDataFromMonday() {
     pulseId = pathMatch[2];
 
     // Fetch projectName
-    const selectedProjectElement = document.querySelector('.home-control-base-item-component.selected .text-with-highlights > span');
+    const selectedProjectElement = document.querySelector('#mf-header h2');
     projectName = selectedProjectElement?.textContent || '';
 
     // Fetch pulseName

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -181,30 +181,50 @@ async function maybeAddTimerButtonToPulse () {
   } catch (e) {}
 }
 
-async function getDataFromMonday () {
-  const path = window.location.pathname
-  const urlBase = new URL(window.location.href).origin
+async function getDataFromMonday() {
+  const path = window.location.pathname;
+  const urlBase = new URL(window.location.href).origin;
 
-  const selectedProject = document.querySelector('.home-control-base-item-component.selected')
-  const projectName = selectedProject?.querySelector('.text-with-highlights > span')?.textContent || ''
+  // Initialize default values
+  let projectName = '';
+  let pulseName = 'Miscellaneous > REPLACE_THIS_WITH_A_DESCRIPTION';
+  let pulseId = 'miscellaneous';
+  let boardId = '';
+  let permalink = '';
 
-  const pulseNameElement = document.querySelector('.pulse_title h2')
-  const pulseName = pulseNameElement?.textContent || ''
+  // Extract boardId and pulseId from path
+  const pathRegex = /\/boards\/(\d+)\/?.*\/pulses\/(\d+)/;
+  const pathMatch = path.match(pathRegex);
 
-  const pulseId = path.substring(path.lastIndexOf('/') + 1) || ''
-  const boardId = path.split('/')[2] || ''
+  if (pathMatch) {
+    boardId = pathMatch[1];
+    pulseId = pathMatch[2];
 
-  const permalink = (urlBase && boardId && pulseId)
-    ? `${urlBase}/boards/${boardId}/pulses/${pulseId}`
-    : (urlBase && boardId && pulseId) ? `${urlBase}/boards/${boardId}` : ''
+    // Fetch projectName
+    const selectedProjectElement = document.querySelector('.home-control-base-item-component.selected .text-with-highlights > span');
+    projectName = selectedProjectElement?.textContent || '';
 
-  if (path.includes('/pulses/')) {
-    return { projectName, pulseName, pulseId, boardId, permalink }
-  } else if (path.includes('/boards/')) {
-    return { projectName, pulseName: 'Miscellaneous > REPLACE_THIS_WITH_A_DESCRIPTION', pulseId: 'miscellaneous', boardId, permalink }
-  } else {
-    return {}
+    // Fetch pulseName
+    const pulseNameElement = document.querySelector('.pulse_title h2');
+    pulseName = pulseNameElement?.textContent || '';
+
+    // Construct permalink
+    if (boardId) {
+      if (pulseId) {
+        permalink = `${urlBase}/boards/${boardId}/pulses/${pulseId}`;
+      } else {
+        permalink = `${urlBase}/boards/${boardId}`;
+      }
+    }
   }
+
+  return {
+    projectName,
+    pulseName,
+    pulseId,
+    boardId,
+    permalink
+  };
 }
 
 async function updateStorage () {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -165,7 +165,7 @@ async function maybeAddTimerButtonToPulse () {
 
       const pulseActionsWrapper = document.querySelector('.pulse_actions_wrapper')
       if (!pulseActionsWrapper) {
-        setTimeout(await maybeAddTimerButtonToPulse(), 3000)
+        setTimeout(await maybeAddTimerButtonToPulse, 3000)
         return
       }
       pulseActionsWrapper.insertAdjacentHTML('beforeend', styles)


### PR DESCRIPTION
Some of the referenced links in my Harvest time entries were broken. They looked like a correct link, but the pulseId was non existent. In that case, monday.com just reported a "Network Problem".

I found out that the pulseId in the broken links actually were postIds, that were incorrectly parsed from the URL.

Here's what my pull request does:
- Fixes the pulseId parsing from the URL path.
- Fixes a setTimeout syntax error, that triggered thousands of function calls on each load.
- Simplifies the CSS selector to fetch the projectName.